### PR TITLE
Add devcontainer for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# Use the base image for TypeScript and Node.js development
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-18
+
+# Install additional dependencies
+RUN npm install libsql drizzle-orm
+
+# Set the working directory
+WORKDIR /workspace
+
+# Copy the project files
+COPY . /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "SvelteKit DevContainer",
+  "build": {
+    "dockerfile": ".devcontainer/Dockerfile"
+  },
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "svelte.svelte-vscode",
+    "ms-vscode.vscode-typescript-next"
+  ],
+  "postCreateCommand": "npm install"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-  "name": "SvelteKit DevContainer",
-  "build": {
-    "dockerfile": ".devcontainer/Dockerfile"
-  },
-  "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash"
-  },
-  "extensions": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "svelte.svelte-vscode",
-    "ms-vscode.vscode-typescript-next"
-  ],
-  "postCreateCommand": "npm install"
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ npx sv create my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `pnpm install`, start a development server:
 
 ```bash
-npm run dev
+pnpm run dev
 
 # or start the server and open the app in a new browser tab
-npm run dev -- --open
+pnpm run dev -- --open
 ```
 
 ## Building
@@ -30,9 +30,20 @@ npm run dev -- --open
 To create a production version of your app:
 
 ```bash
-npm run build
+pnpm run build
 ```
 
-You can preview the production build with `npm run preview`.
+You can preview the production build with `pnpm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Using DevContainers for Development
+
+You can use DevContainers to create a consistent development environment. Follow these steps to open the project in a DevContainer:
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for Visual Studio Code.
+2. Open the project in Visual Studio Code.
+3. Press `F1` and select `Remote-Containers: Open Folder in Container...`.
+4. Select the project folder.
+
+This will open the project in a DevContainer with all the necessary dependencies and tools pre-installed.


### PR DESCRIPTION
Add devcontainer configuration and update README.md to use pnpm.

* **README.md**
  - Update instructions to use `pnpm` instead of `npm` for installing dependencies, starting the development server, building, and previewing the production build.
  - Add a section about using DevContainers for development.

* **.devcontainer/devcontainer.json**
  - Define the name of the devcontainer as "SvelteKit DevContainer".
  - Set the Dockerfile path to `.devcontainer/Dockerfile`.
  - Configure settings for VS Code extensions and features.

* **.devcontainer/Dockerfile**
  - Use `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-18` as the base image.
  - Install additional dependencies like `libsql` and `drizzle-orm`.
  - Set up the working directory and copy the project files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nonameolsson/budgt/pull/1?shareId=d83e24bc-9e8f-416f-90c7-8c5ec6ffc561).