### PR TITLE
Add confirmation modal for account deletion

### DIFF
--- a/src/components/ConfirmModal.svelte
+++ b/src/components/ConfirmModal.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  export let isVisible: boolean;
+  export let onProceed: () => void;
+  export let onCancel: () => void;
+</script>
+
+{#if isVisible}
+  <div class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-75">
+    <div class="bg-white p-6 rounded shadow-md">
+      <h2 class="text-xl font-bold mb-4">Confirm Deletion</h2>
+      <p class="mb-4">Are you sure you want to delete this account? This action cannot be undone and will delete all related expenses.</p>
+      <div class="flex justify-end">
+        <button on:click={onCancel} class="mr-2 rounded bg-gray-500 px-4 py-2 text-white">Cancel</button>
+        <button on:click={onProceed} class="rounded bg-red-500 px-4 py-2 text-white">Delete</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .fixed {
+    position: fixed;
+  }
+  .inset-0 {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+  .flex {
+    display: flex;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .justify-center {
+    justify-content: center;
+  }
+  .bg-gray-800 {
+    background-color: #2d3748;
+  }
+  .bg-opacity-75 {
+    background-opacity: 0.75;
+  }
+  .bg-white {
+    background-color: #ffffff;
+  }
+  .p-6 {
+    padding: 1.5rem;
+  }
+  .rounded {
+    border-radius: 0.375rem;
+  }
+  .shadow-md {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  }
+  .text-xl {
+    font-size: 1.25rem;
+  }
+  .font-bold {
+    font-weight: 700;
+  }
+  .mb-4 {
+    margin-bottom: 1rem;
+  }
+  .justify-end {
+    justify-content: flex-end;
+  }
+  .mr-2 {
+    margin-right: 0.5rem;
+  }
+  .bg-gray-500 {
+    background-color: #6b7280;
+  }
+  .px-4 {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+  .py-2 {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  .text-white {
+    color: #ffffff;
+  }
+  .bg-red-500 {
+    background-color: #ef4444;
+  }
+</style>

--- a/src/components/ConfirmModal.svelte
+++ b/src/components/ConfirmModal.svelte
@@ -5,13 +5,13 @@
 </script>
 
 {#if isVisible}
-  <div class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-75">
-    <div class="bg-white p-6 rounded shadow-md">
+  <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+    <div class="bg-white p-6 rounded shadow-lg">
       <h2 class="text-xl font-bold mb-4">Confirm Deletion</h2>
       <p class="mb-4">Are you sure you want to delete this account? This action cannot be undone and will delete all related expenses.</p>
-      <div class="flex justify-end">
-        <button on:click={onCancel} class="mr-2 rounded bg-gray-500 px-4 py-2 text-white">Cancel</button>
-        <button on:click={onProceed} class="rounded bg-red-500 px-4 py-2 text-white">Delete</button>
+      <div class="flex justify-end space-x-4">
+        <button on:click={onCancel} class="px-4 py-2 bg-gray-500 text-white rounded">Cancel</button>
+        <button on:click={onProceed} class="px-4 py-2 bg-red-500 text-white rounded">Delete</button>
       </div>
     </div>
   </div>
@@ -36,14 +36,14 @@
   .justify-center {
     justify-content: center;
   }
-  .bg-gray-800 {
-    background-color: #2d3748;
+  .bg-black {
+    background-color: black;
   }
-  .bg-opacity-75 {
-    background-opacity: 0.75;
+  .bg-opacity-50 {
+    background-opacity: 0.5;
   }
   .bg-white {
-    background-color: #ffffff;
+    background-color: white;
   }
   .p-6 {
     padding: 1.5rem;
@@ -51,8 +51,8 @@
   .rounded {
     border-radius: 0.375rem;
   }
-  .shadow-md {
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  .shadow-lg {
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .text-xl {
     font-size: 1.25rem;
@@ -66,11 +66,8 @@
   .justify-end {
     justify-content: flex-end;
   }
-  .mr-2 {
-    margin-right: 0.5rem;
-  }
-  .bg-gray-500 {
-    background-color: #6b7280;
+  .space-x-4 > :not(:last-child) {
+    margin-right: 1rem;
   }
   .px-4 {
     padding-left: 1rem;
@@ -80,8 +77,11 @@
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
   }
+  .bg-gray-500 {
+    background-color: #6b7280;
+  }
   .text-white {
-    color: #ffffff;
+    color: white;
   }
   .bg-red-500 {
     background-color: #ef4444;

--- a/src/lib/components/ConfirmModal.svelte
+++ b/src/lib/components/ConfirmModal.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	export let visible: boolean;
+	export let id: string | null;
+	export let onCancel: () => void;
+</script>
+
+{#if visible}
+	<form method="POST" action="?/deleteAccount">
+		<input type="hidden" name="id" value={id} />
+		<div class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-75">
+			<div class="rounded bg-white p-6 shadow-md">
+				<h2 class="mb-4 text-xl font-bold">Confirm Deletion</h2>
+				<p class="mb-4">
+					Are you sure you want to delete this account? This action cannot be undone and will delete
+					all related expenses.
+				</p>
+				<div class="flex justify-end space-x-4">
+					<button on:click={onCancel} class="rounded bg-gray-500 px-4 py-2 text-white"
+						>Cancel</button
+					>
+					<button type="submit" class="rounded bg-red-500 px-4 py-2 text-white">Proceed</button>
+				</div>
+			</div>
+		</div>
+	</form>
+{/if}

--- a/src/lib/server/db/accounts.ts
+++ b/src/lib/server/db/accounts.ts
@@ -2,6 +2,7 @@ import { Value } from '@sinclair/typebox/value';
 import { eq } from 'drizzle-orm';
 import { db } from '.';
 import { accountInsertSchema, accounts, type InsertAccount } from './schema';
+import { expenses } from './schema';
 
 export async function createAccount(data: InsertAccount) {
 	const parsed = Value.Parse(accountInsertSchema, data);
@@ -14,5 +15,6 @@ export async function getAccounts() {
 }
 
 export async function deleteAccount(id: string) {
+	await db.delete(expenses).where(eq(expenses.accountId, id));
 	return await db.delete(accounts).where(eq(accounts.id, id));
 }

--- a/src/lib/server/db/accounts.ts
+++ b/src/lib/server/db/accounts.ts
@@ -1,7 +1,7 @@
 import { Value } from '@sinclair/typebox/value';
 import { eq } from 'drizzle-orm';
 import { db } from '.';
-import { accountInsertSchema, accounts, type InsertAccount, expenses } from './schema';
+import { accountInsertSchema, accounts, expenses, type InsertAccount } from './schema';
 
 export async function createAccount(data: InsertAccount) {
 	const parsed = Value.Parse(accountInsertSchema, data);

--- a/src/lib/server/db/accounts.ts
+++ b/src/lib/server/db/accounts.ts
@@ -1,8 +1,7 @@
 import { Value } from '@sinclair/typebox/value';
 import { eq } from 'drizzle-orm';
 import { db } from '.';
-import { accountInsertSchema, accounts, type InsertAccount } from './schema';
-import { expenses } from './schema';
+import { accountInsertSchema, accounts, type InsertAccount, expenses } from './schema';
 
 export async function createAccount(data: InsertAccount) {
 	const parsed = Value.Parse(accountInsertSchema, data);

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -1,6 +1,35 @@
 <script lang="ts">
 	let { data } = $props();
 	import { enhance } from '$app/forms';
+	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
+
+	let isModalVisible = false;
+	let selectedAccountId: string | null = null;
+
+	function showModal(accountId: string) {
+		selectedAccountId = accountId;
+		isModalVisible = true;
+	}
+
+	function hideModal() {
+		selectedAccountId = null;
+		isModalVisible = false;
+	}
+
+	async function proceedDelete() {
+		if (selectedAccountId) {
+			const formData = new FormData();
+			formData.append('id', selectedAccountId);
+
+			await fetch('?/deleteAccount', {
+				method: 'POST',
+				body: formData
+			});
+
+			hideModal();
+			location.reload();
+		}
+	}
 </script>
 
 <div class="container mx-auto p-4">
@@ -13,14 +42,19 @@
 			<li class="mb-2 flex justify-between">
 				<span>{account.name}</span>
 				<span>{account.balance}:-</span>
-				<form method="POST" action="?/deleteAccount" use:enhance>
-					<input type="hidden" name="id" value={account.id} />
-					<button type="submit" class="rounded bg-red-500 p-2 text-white">Delete</button>
-				</form>
+				<button on:click={() => showModal(account.id)} class="rounded bg-red-500 p-2 text-white">
+					Delete
+				</button>
 			</li>
 		{/each}
 	</ul>
 </div>
+
+<ConfirmModal
+	isVisible={isModalVisible}
+	onProceed={proceedDelete}
+	onCancel={hideModal}
+/>
 
 <style>
 </style>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -1,34 +1,18 @@
 <script lang="ts">
-	let { data } = $props();
-	import { enhance } from '$app/forms';
 	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
 
-	let isModalVisible = false;
-	let selectedAccountId: string | null = null;
+	let { data } = $props();
+	let isModalVisible = $state(false);
+	let selectedAccountId: string | null = $state(null);
 
-	function showModal(accountId: string) {
+	function showDeleteModal(accountId: string) {
 		selectedAccountId = accountId;
 		isModalVisible = true;
 	}
 
-	function hideModal() {
-		selectedAccountId = null;
+	function handleCancel() {
 		isModalVisible = false;
-	}
-
-	async function proceedDelete() {
-		if (selectedAccountId) {
-			const formData = new FormData();
-			formData.append('id', selectedAccountId);
-
-			await fetch('?/deleteAccount', {
-				method: 'POST',
-				body: formData
-			});
-
-			hideModal();
-			location.reload();
-		}
+		selectedAccountId = null;
 	}
 </script>
 
@@ -42,19 +26,13 @@
 			<li class="mb-2 flex justify-between">
 				<span>{account.name}</span>
 				<span>{account.balance}:-</span>
-				<button on:click={() => showModal(account.id)} class="rounded bg-red-500 p-2 text-white">
-					Delete
-				</button>
+				<button
+					onclick={() => showDeleteModal(account.id)}
+					class="rounded bg-red-500 p-2 text-white">Delete</button
+				>
 			</li>
 		{/each}
 	</ul>
 </div>
 
-<ConfirmModal
-	isVisible={isModalVisible}
-	onProceed={proceedDelete}
-	onCancel={hideModal}
-/>
-
-<style>
-</style>
+<ConfirmModal visible={isModalVisible} id={selectedAccountId} onCancel={handleCancel} />


### PR DESCRIPTION
Add confirmation modal for account deletion and handle related expenses.

* **Database Changes:**
  - Update `deleteAccount` function in `src/lib/server/db/accounts.ts` to delete related expenses before deleting the account.

* **Modal Component:**
  - Create `src/components/ConfirmModal.svelte` for the confirmation modal.
  - Include props for modal visibility and callback functions for proceed and cancel actions.
  - Add HTML and CSS for the modal layout and styling.

* **Page Changes:**
  - Import and include the `ConfirmModal` component in `src/routes/accounts/+page.svelte`.
  - Add state variables to handle modal visibility and selected account id.
  - Update the delete button to trigger the modal instead of directly deleting the account.
  - Add functions to handle proceed and cancel actions from the modal.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nonameolsson/budgt/pull/16?shareId=fd69dfba-66b3-4e40-8da4-60746911e63a).