### PR TITLE
Allow the user to set one account as the primary account

### DIFF
--- a/docs/Business_Logic.md
+++ b/docs/Business_Logic.md
@@ -62,11 +62,12 @@
 
 - Validate that the account name is unique.
 - Ensure that the initial balance is a positive number.
+- Ensure that only one account can be set as the primary account at a time.
 
 ### Database Modeling
 
 - Table: `accounts`
-  - Columns: `id`, `name`, `balance`, `created_at`, `updated_at`
+  - Columns: `id`, `name`, `balance`, `created_at`, `updated_at`, `is_primary`
 
 ### Example Queries
 
@@ -79,6 +80,11 @@
   DELETE FROM accounts WHERE id = ?;
   DELETE FROM expenses WHERE accountId = ?;
   DELETE FROM income WHERE accountId = ?;
+  ```
+- Set Primary Account:
+  ```sql
+  UPDATE accounts SET is_primary = 0 WHERE is_primary = 1;
+  UPDATE accounts SET is_primary = 1 WHERE id = ?;
   ```
 
 ## Managing Categories

--- a/docs/MVP_Features.md
+++ b/docs/MVP_Features.md
@@ -23,6 +23,7 @@
 - As a user, I want to create an account with a name and initial balance so that I can track my finances.
 - As a user, I want to view a list of all my accounts so that I can see my financial overview.
 - As a user, I want to delete an account so that I can remove accounts I no longer use.
+- As a user, I want to set an account as the primary account so that I can easily identify my main account.
 
 ## Managing Categories
 

--- a/migrations/0003_noisy_living_tribunal.sql
+++ b/migrations/0003_noisy_living_tribunal.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `accounts` ALTER COLUMN "updated_at" TO "updated_at" text NOT NULL DEFAULT '2024-12-30T11:13:14.540Z';--> statement-breakpoint
+ALTER TABLE `accounts` ADD `is_primary` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `categories` ALTER COLUMN "created_at" TO "created_at" text NOT NULL DEFAULT '2024-12-30T11:13:14.531Z';--> statement-breakpoint
+ALTER TABLE `categories` ALTER COLUMN "updated_at" TO "updated_at" text NOT NULL DEFAULT '2024-12-30T11:13:14.536Z';--> statement-breakpoint
+ALTER TABLE `expenses` ALTER COLUMN "created_at" TO "created_at" text NOT NULL DEFAULT '2024-12-30T11:13:14.538Z';--> statement-breakpoint
+ALTER TABLE `expenses` ALTER COLUMN "updated_at" TO "updated_at" text NOT NULL DEFAULT '2024-12-30T11:13:14.538Z';

--- a/migrations/0004_demonic_jetstream.sql
+++ b/migrations/0004_demonic_jetstream.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `accounts` ALTER COLUMN "updated_at" TO "updated_at" text NOT NULL DEFAULT '2024-12-30T11:25:47.636Z';--> statement-breakpoint
+ALTER TABLE `accounts` ALTER COLUMN "is_primary" TO "is_primary" integer NOT NULL DEFAULT false;--> statement-breakpoint
+ALTER TABLE `categories` ALTER COLUMN "created_at" TO "created_at" text NOT NULL DEFAULT '2024-12-30T11:25:47.633Z';--> statement-breakpoint
+ALTER TABLE `categories` ALTER COLUMN "updated_at" TO "updated_at" text NOT NULL DEFAULT '2024-12-30T11:25:47.635Z';--> statement-breakpoint
+ALTER TABLE `expenses` ALTER COLUMN "created_at" TO "created_at" text NOT NULL DEFAULT '2024-12-30T11:25:47.636Z';--> statement-breakpoint
+ALTER TABLE `expenses` ALTER COLUMN "updated_at" TO "updated_at" text NOT NULL DEFAULT '2024-12-30T11:25:47.636Z';

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,180 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "c6fb55a1-b10c-4ca0-baa5-a1c7d0603e29",
+	"prevId": "a8d9d58d-6427-4733-bd4f-8b9e24891a36",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:13:14.540Z'"
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"categories": {
+			"name": "categories",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:13:14.531Z'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:13:14.536Z'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"expenses": {
+			"name": "expenses",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:13:14.538Z'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:13:14.538Z'"
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"categoryId": {
+					"name": "categoryId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,180 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "4c5f65a7-e38f-4953-8dc9-9df3d6bf04fd",
+	"prevId": "c6fb55a1-b10c-4ca0-baa5-a1c7d0603e29",
+	"tables": {
+		"accounts": {
+			"name": "accounts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:25:47.636Z'"
+				},
+				"is_primary": {
+					"name": "is_primary",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"categories": {
+			"name": "categories",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:25:47.633Z'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:25:47.635Z'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"expenses": {
+			"name": "expenses",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:25:47.636Z'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'2024-12-30T11:25:47.636Z'"
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"categoryId": {
+					"name": "categoryId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,20 @@
 			"when": 1735554113840,
 			"tag": "0002_open_natasha_romanoff",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1735557194559,
+			"tag": "0003_noisy_living_tribunal",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1735557947644,
+			"tag": "0004_demonic_jetstream",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/accounts.ts
+++ b/src/lib/server/db/accounts.ts
@@ -12,6 +12,14 @@ import { expenses } from './schema/expenses';
 export async function createAccount(data: InsertAccountSchema) {
 	const parsed = Value.Parse(insertAccountSchema, data);
 
+	const existingPrimaryAccount = await db.query.accounts.findFirst({
+		where: eq(accounts.is_primary, true)
+	});
+
+	if (!existingPrimaryAccount) {
+		parsed.is_primary = true;
+	}
+
 	return await db.insert(accounts).values(parsed);
 }
 
@@ -24,10 +32,27 @@ export async function getAccount(id: string) {
 }
 
 export async function deleteAccount(id: string) {
+	const accountToDelete = await db.query.accounts.findFirst({ where: eq(accounts.id, id) });
+
+	if (accountToDelete?.is_primary) {
+		const otherAccount = await db.query.accounts.findFirst({
+			where: eq(accounts.is_primary, false)
+		});
+
+		if (otherAccount) {
+			await db.update(accounts).set({ is_primary: true }).where(eq(accounts.id, otherAccount.id));
+		}
+	}
+
 	await db.delete(expenses).where(eq(expenses.accountId, id));
 	return await db.delete(accounts).where(eq(accounts.id, id));
 }
 
 export async function updateAccount(id: string, data: UpdateAccountSchema) {
 	return await db.update(accounts).set(data).where(eq(accounts.id, id));
+}
+
+export async function setPrimaryAccount(id: string) {
+	await db.update(accounts).set({ is_primary: false }).where(eq(accounts.is_primary, true));
+	return await db.update(accounts).set({ is_primary: true }).where(eq(accounts.id, id));
 }

--- a/src/lib/server/db/accounts.ts
+++ b/src/lib/server/db/accounts.ts
@@ -20,6 +20,10 @@ export async function createAccount(data: InsertAccountSchema) {
 		parsed.is_primary = true;
 	}
 
+	if (parsed.is_primary) {
+		await db.update(accounts).set({ is_primary: false }).where(eq(accounts.is_primary, true));
+	}
+
 	return await db.insert(accounts).values(parsed);
 }
 
@@ -49,10 +53,6 @@ export async function deleteAccount(id: string) {
 }
 
 export async function updateAccount(id: string, data: UpdateAccountSchema) {
-	return await db.update(accounts).set(data).where(eq(accounts.id, id));
-}
-
-export async function setPrimaryAccount(id: string) {
 	await db.update(accounts).set({ is_primary: false }).where(eq(accounts.is_primary, true));
-	return await db.update(accounts).set({ is_primary: true }).where(eq(accounts.id, id));
+	return await db.update(accounts).set(data).where(eq(accounts.id, id));
 }

--- a/src/lib/server/db/schema/accounts.ts
+++ b/src/lib/server/db/schema/accounts.ts
@@ -1,7 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import type { Static } from '@sinclair/typebox';
 import { relations } from 'drizzle-orm';
-import { real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { real, sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 import { createInsertSchema, createSelectSchema, createUpdateSchema } from 'drizzle-typebox';
 import { expenses } from './expenses';
 
@@ -19,7 +19,8 @@ export const accounts = sqliteTable('accounts', {
 	updatedAt: text('updated_at')
 		.notNull()
 		.default(new Date().toISOString())
-		.$onUpdateFn(() => new Date().toISOString())
+		.$onUpdateFn(() => new Date().toISOString()),
+	is_primary: integer('is_primary').notNull().default(0)
 });
 
 export const insertAccountSchema = createInsertSchema(accounts);

--- a/src/lib/server/db/schema/accounts.ts
+++ b/src/lib/server/db/schema/accounts.ts
@@ -1,7 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import type { Static } from '@sinclair/typebox';
 import { relations } from 'drizzle-orm';
-import { real, sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { createInsertSchema, createSelectSchema, createUpdateSchema } from 'drizzle-typebox';
 import { expenses } from './expenses';
 
@@ -10,7 +10,7 @@ export const accounts = sqliteTable('accounts', {
 		.$defaultFn(() => createId())
 		.notNull()
 		.primaryKey(),
-	name: text('name').notNull(),
+	name: text('name').notNull(), // TODO: Make unique
 	balance: real('balance').notNull(),
 	createdAt: text('created_at')
 		.notNull()
@@ -20,7 +20,7 @@ export const accounts = sqliteTable('accounts', {
 		.notNull()
 		.default(new Date().toISOString())
 		.$onUpdateFn(() => new Date().toISOString()),
-	is_primary: integer('is_primary').notNull().default(0)
+	is_primary: integer({ mode: 'boolean' }).notNull().default(false)
 });
 
 export const insertAccountSchema = createInsertSchema(accounts);

--- a/src/lib/server/db/schema/categories.ts
+++ b/src/lib/server/db/schema/categories.ts
@@ -8,7 +8,7 @@ export const categories = sqliteTable('categories', {
 		.$defaultFn(() => createId())
 		.notNull()
 		.primaryKey(),
-	name: text('name').notNull(),
+	name: text('name').notNull(), // TODO: Make unique
 	createdAt: text('created_at')
 		.notNull()
 		.default(new Date().toISOString())

--- a/src/routes/accounts/+page.server.ts
+++ b/src/routes/accounts/+page.server.ts
@@ -1,4 +1,4 @@
-import { deleteAccount, getAccounts, setPrimaryAccount } from '$lib/server/db/accounts';
+import { deleteAccount, getAccounts } from '$lib/server/db/accounts';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -14,12 +14,5 @@ export const actions: Actions = {
 		if (id === null) return;
 
 		await deleteAccount(String(id));
-	},
-	setPrimaryAccount: async ({ request }) => {
-		const data = await request.formData();
-		const id = data.get('id');
-		if (id === null) return;
-
-		await setPrimaryAccount(String(id));
 	}
 } satisfies Actions;

--- a/src/routes/accounts/+page.server.ts
+++ b/src/routes/accounts/+page.server.ts
@@ -1,4 +1,4 @@
-import { deleteAccount, getAccounts } from '$lib/server/db/accounts';
+import { deleteAccount, getAccounts, setPrimaryAccount } from '$lib/server/db/accounts';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -14,5 +14,12 @@ export const actions: Actions = {
 		if (id === null) return;
 
 		await deleteAccount(String(id));
+	},
+	setPrimaryAccount: async ({ request }) => {
+		const data = await request.formData();
+		const id = data.get('id');
+		if (id === null) return;
+
+		await setPrimaryAccount(String(id));
 	}
 } satisfies Actions;

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -13,6 +13,16 @@
 		isModalVisible = false;
 		selectedAccountId = null;
 	}
+
+	async function handleSetPrimary(accountId: string) {
+		const formData = new FormData();
+		formData.append('id', accountId);
+
+		await fetch('/accounts/setPrimaryAccount', {
+			method: 'POST',
+			body: formData
+		});
+	}
 </script>
 
 <div class="container mx-auto p-4">
@@ -31,6 +41,10 @@
 				<button
 					onclick={() => showDeleteModal(account.id)}
 					class="rounded bg-red-500 p-2 text-white">Delete</button
+				>
+				<button
+					onclick={() => handleSetPrimary(account.id)}
+					class="rounded bg-green-500 p-2 text-white">Set as Primary</button
 				>
 			</li>
 		{/each}

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -13,16 +13,6 @@
 		isModalVisible = false;
 		selectedAccountId = null;
 	}
-
-	async function handleSetPrimary(accountId: string) {
-		const formData = new FormData();
-		formData.append('id', accountId);
-
-		await fetch('/accounts/setPrimaryAccount', {
-			method: 'POST',
-			body: formData
-		});
-	}
 </script>
 
 <div class="container mx-auto p-4">
@@ -35,16 +25,15 @@
 			<li class="mb-2 flex justify-between">
 				<span>{account.name}</span>
 				<span>{account.balance}:-</span>
+				{#if account.is_primary}
+					<span class="text-green-500">Primary</span>
+				{/if}
 				<a href={`/accounts/edit/${account.id}`} class="rounded bg-yellow-500 p-2 text-white">
 					Edit
 				</a>
 				<button
 					onclick={() => showDeleteModal(account.id)}
 					class="rounded bg-red-500 p-2 text-white">Delete</button
-				>
-				<button
-					onclick={() => handleSetPrimary(account.id)}
-					class="rounded bg-green-500 p-2 text-white">Set as Primary</button
 				>
 			</li>
 		{/each}

--- a/src/routes/accounts/create/+page.server.ts
+++ b/src/routes/accounts/create/+page.server.ts
@@ -21,7 +21,8 @@ export const actions: Actions = {
 
 		const newAccount: InsertAccountSchema = {
 			name: form.data.name,
-			balance: form.data.balance
+			balance: form.data.balance,
+			is_primary: form.data.is_primary
 		};
 
 		await createAccount(newAccount);

--- a/src/routes/accounts/create/+page.svelte
+++ b/src/routes/accounts/create/+page.svelte
@@ -33,11 +33,18 @@
 			placeholder="Balance"
 			class="w-full rounded border border-gray-300 p-2"
 			aria-invalid={$errors.balance ? 'true' : undefined}
+			{...$constraints.name}
 		/>
-		<!-- {...$constraints.name} -->
 		{#if $errors.balance}
 			<p class="text-red-500">{$errors.balance}</p>
 		{/if}
+		<label for="is_primary" class="text-gray-700">Primary Account</label>
+		<input
+			type="checkbox"
+			bind:checked={$form.is_primary}
+			name="is_primary"
+			class="rounded border border-gray-300 p-2"
+		/>
 		<div class="flex justify-between">
 			<a href="/accounts" class="rounded bg-gray-500 p-2 text-white">Cancel</a>
 			<button type="submit" class="rounded bg-blue-500 p-2 text-white">Add</button>

--- a/src/routes/accounts/edit/[id]/+page.server.ts
+++ b/src/routes/accounts/edit/[id]/+page.server.ts
@@ -34,7 +34,8 @@ export const actions: Actions = {
 
 		const data: UpdateAccountSchema = {
 			name: form.data.name,
-			balance: form.data.balance
+			balance: form.data.balance,
+			is_primary: form.data.is_primary
 		};
 		await updateAccount(params.id, data);
 

--- a/src/routes/accounts/edit/[id]/+page.svelte
+++ b/src/routes/accounts/edit/[id]/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-	import { superForm } from 'sveltekit-superforms';
+	import SuperDebug, { superForm } from 'sveltekit-superforms';
 
 	let { data } = $props();
 
 	const { form, errors, constraints, message, enhance } = superForm(data.form);
 </script>
+
+<SuperDebug data={$form} />
 
 <div class="container mx-auto p-4">
 	<h1 class="mb-4 text-2xl font-bold">Edit Account</h1>
@@ -41,6 +43,13 @@
 		{#if $errors.balance}
 			<p class="text-red-500">{$errors.balance}</p>
 		{/if}
+		<label for="is_primary" class="text-gray-700">Primary Account</label>
+		<input
+			type="checkbox"
+			bind:checked={$form.is_primary}
+			name="is_primary"
+			class="rounded border border-gray-300 p-2"
+		/>
 		<div class="flex justify-between">
 			<a href="/accounts" class="rounded bg-gray-500 p-2 text-white">Cancel</a>
 			<button type="submit" class="rounded bg-blue-500 p-2 text-white">Save</button>

--- a/src/routes/expenses/create/+page.svelte
+++ b/src/routes/expenses/create/+page.svelte
@@ -35,9 +35,13 @@
 			value={getCurrentDate()}
 		/>
 		<select name="accountId" required class="w-full rounded border border-gray-300 p-2">
-			<option value="" disabled selected>Select Account</option>
-			{#each data.accounts as { id, name }}
-				<option value={id}>{name}</option>
+			{#if data.accounts.length === 0}
+				<option value="" disabled selected>No Accounts</option>
+			{:else if !data.accounts.some((account) => account.is_primary)}
+				<option value="" disabled selected>Select Account</option>
+			{/if}
+			{#each data.accounts as { id, is_primary, name }}
+				<option selected={is_primary} value={id}>{name}</option>
 			{/each}
 		</select>
 		<select name="categoryId" required class="w-full rounded border border-gray-300 p-2">


### PR DESCRIPTION
Add functionality to set one account as the primary account.

* **Business Logic and Database Modeling:**
  - Update `docs/Business_Logic.md` to ensure only one account can be set as primary at a time.
  - Add `is_primary` column to `accounts` table in `docs/Business_Logic.md`.
  - Add example queries for setting the primary account in `docs/Business_Logic.md`.

* **User Stories:**
  - Add a user story for setting an account as the primary account in `docs/MVP_Features.md`.

* **Database Schema:**
  - Add `is_primary` column to `accounts` table definition in `src/lib/server/db/schema/accounts.ts`.

* **Database Operations:**
  - Add `setPrimaryAccount` function to update primary account status in `src/lib/server/db/accounts.ts`.
  - Update `createAccount` function to set new account as primary if no primary account exists in `src/lib/server/db/accounts.ts`.
  - Update `deleteAccount` function to handle primary account deletion in `src/lib/server/db/accounts.ts`.

* **Server Actions:**
  - Add `setPrimaryAccount` action to handle setting an account as primary in `src/routes/accounts/+page.server.ts`.

* **Frontend:**
  - Add button to set an account as primary in `src/routes/accounts/+page.svelte`.
  - Add `handleSetPrimary` function to call `setPrimaryAccount` action in `src/routes/accounts/+page.svelte`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nonameolsson/budgt/pull/32?shareId=245edfb4-48ce-4011-b6b9-a3e146dd567c).