### PR TITLE
Remove pino-pretty from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"lint-staged": "^15.3.0",
 		"npm-check-updates": "^17.1.13",
 		"npm-run-all": "^4.1.5",
+		"pino-pretty": "^13.0.0",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.2",
 		"prettier-plugin-tailwindcss": "^0.6.9",
@@ -63,7 +64,6 @@
 		"drizzle-orm": "^0.38.3",
 		"drizzle-typebox": "^0.2.1",
 		"eslint-plugin-drizzle": "^0.2.3",
-		"pino": "^9.6.0",
-		"pino-pretty": "^13.0.0"
+		"pino": "^9.6.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.6.0
-      pino-pretty:
-        specifier: ^13.0.0
-        version: 13.0.0
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.4
@@ -96,6 +93,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.0.0
       prettier:
         specifier: ^3.4.2
         version: 3.4.2


### PR DESCRIPTION
Eliminate the pino-pretty package from both dependencies and devDependencies in package.json and pnpm-lock.yaml.